### PR TITLE
Fix ¯\_ಠ ͟ʖಠ_/¯

### DIFF
--- a/_posts/2015-09-14-reactjs-the-good-and-the-bad.md
+++ b/_posts/2015-09-14-reactjs-the-good-and-the-bad.md
@@ -38,7 +38,7 @@ Most of our engineering work is for internal applications--warehouse management 
 Nowadays, we maintain a repository with shared ES6 (or ES2015/2016) components that we can pull into our applications with NPM. We don't need our systems to be paint-by-numbers, but there [atomic pieces](http://atomicdesign.bradfrost.com/chapter-2/) of interface logic that can easily be shared. And with React's component model (and a little help from Babel and Webpack), we have an ironclad contract as to the component's lifecycle in the application.
 
 
-## So should you use React in your javascript applications? ¯\_ಠ ͟ʖಠ_/¯
+## So should you use React in your javascript applications? ¯\\\_ಠ ͟ʖಠ_/¯
 
 ### You already use [Webpack](https://webpack.github.io/) or something similar
 


### PR DESCRIPTION
Escape backslash and underscore.

Note: I don't know what changed in the line 73, but it was caused by something in the GitHub online editor. I expect that it will not break anything.
